### PR TITLE
Fix results copy path and preprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ML Pipeline Demo
 
-This project demonstrates a simple machine learning pipeline orchestrated with **Apache Airflow**. The pipeline trains a logistic regression model on the Breast Cancer Wisconsin dataset and stores the resulting model and metrics in the `results/` directory.
+This project demonstrates a simple machine learning pipeline orchestrated with **Apache Airflow**. The pipeline trains a logistic regression model on the Breast Cancer Wisconsin dataset and stores the resulting model and metrics in the `results/final/` directory.
 
 ## Project Structure
 
@@ -17,10 +17,10 @@ This project demonstrates a simple machine learning pipeline orchestrated with *
 ## Pipeline Steps
 
 1. **Load Data** – fetch the dataset with `sklearn.datasets.load_breast_cancer` and save it as CSV.
-2. **Preprocess** – simple cleanup (column renaming to lowercase).
+2. **Preprocess** – cleanup (column normalization, duplicate removal, scaling).
 3. **Train Model** – train `LogisticRegression` and persist the model with `joblib`.
 4. **Evaluate** – calculate accuracy, precision, recall and F1; store metrics in JSON.
-5. **Save Results** – copy resulting artifacts to `results/` (placeholder for cloud upload).
+5. **Save Results** – copy resulting artifacts to `results/final/` (placeholder for cloud upload).
 
 A simplified flow is:
 
@@ -51,11 +51,11 @@ python etl/evaluate.py
 python etl/save_results.py
 ```
 
-Artifacts (`model.pkl` and `metrics.json`) will appear in `results/`.
+Artifacts (`model.pkl` and `metrics.json`) will appear in `results/final/`.
 
 ## Integration
 
-For demonstration, the integration step simply copies artifacts to `results/`. In a real environment this function can be extended to upload files to cloud storage (S3, Google Drive, etc.) using credentials stored outside the repository.
+For demonstration, the integration step simply copies artifacts to `results/final/`. In a real environment this function can be extended to upload files to cloud storage (S3, Google Drive, etc.) using credentials stored outside the repository.
 
 ## Error Handling & Robustness
 

--- a/config.py
+++ b/config.py
@@ -1,4 +1,7 @@
+import os
+
 RESULTS_DIR = 'results'
+FINAL_DIR = os.path.join(RESULTS_DIR, 'final')
 DATA_FILE = 'data.csv'
 MODEL_FILE = 'model.pkl'
 METRICS_FILE = 'metrics.json'

--- a/etl/preprocess.py
+++ b/etl/preprocess.py
@@ -1,14 +1,24 @@
 import pandas as pd
+from sklearn.preprocessing import StandardScaler
 import os
 import config
 
 
 def preprocess(input_path, output_path=None):
     df = pd.read_csv(input_path)
-    # simple preprocessing: lowercase column names
+    # normalize column names
     df.columns = [c.lower().strip().replace(' ', '_') for c in df.columns]
+
+    df.drop_duplicates(inplace=True)
+    df.fillna(df.median(), inplace=True)
+
+    scaler = StandardScaler()
+    feature_cols = [c for c in df.columns if c != 'target']
+    df[feature_cols] = scaler.fit_transform(df[feature_cols])
+
     if output_path is None:
         output_path = input_path  # overwrite
+
     df.to_csv(output_path, index=False)
     return output_path
 

--- a/etl/save_results.py
+++ b/etl/save_results.py
@@ -4,11 +4,16 @@ import config
 
 
 def save_to_storage(source_paths, dest_dir=None):
+    """Copy artifacts to the final storage directory."""
     if dest_dir is None:
-        dest_dir = config.RESULTS_DIR
+        dest_dir = config.FINAL_DIR
     os.makedirs(dest_dir, exist_ok=True)
     for p in source_paths:
-        shutil.copy(p, dest_dir)
+        dest_path = os.path.join(dest_dir, os.path.basename(p))
+        if os.path.abspath(p) == os.path.abspath(dest_path):
+            # Avoid SameFileError when source and destination are identical
+            continue
+        shutil.copy(p, dest_path)
 
 if __name__ == '__main__':
     paths = [


### PR DESCRIPTION
## Summary
- improve preprocessing with scaling and deduplication
- avoid SameFileError by copying artifacts to results/final
- document new location in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `PYTHONPATH=. python etl/load_data.py && PYTHONPATH=. python etl/preprocess.py && PYTHONPATH=. python etl/train_model.py && PYTHONPATH=. python etl/evaluate.py && PYTHONPATH=. python etl/save_results.py`

------
https://chatgpt.com/codex/tasks/task_e_68523ad08cc0832ab9428f17143584c5